### PR TITLE
Add sdpa as attention backend option

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -274,7 +274,7 @@ class Trellis2LoadModel:
         return {
             "required": {
                 "modelname": (["TRELLIS.2-4B"],),
-                "backend": (["flash_attn","xformers"],{"default":"xformers"}),
+                "backend": (["xformers","sdpa","flash_attn"],{"default":"xformers"}),
                 "device": (["cpu","cuda"],{"default":"cuda"}),
                 "low_vram": ("BOOLEAN",{"default":True}),
                 "keep_models_loaded": ("BOOLEAN", {"default":True}),

--- a/trellis2/modules/attention/config.py
+++ b/trellis2/modules/attention/config.py
@@ -1,6 +1,6 @@
 from typing import *
 
-BACKEND = 'flash_attn' 
+BACKEND = 'sdpa'
 DEBUG = False
 
 def __from_env():


### PR DESCRIPTION
Add 'sdpa' (PyTorch scaled_dot_product_attention) and reorder backends so xformers is default, with sdpa as a no-install fallback for users who don't have flash_attn or xformers.