### PR TITLE
Update backend options and force configuration module updates

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -37,6 +37,8 @@ import comfy.utils
 
 from .trellis2.pipelines import Trellis2ImageTo3DPipeline
 from .trellis2.representations import Mesh, MeshWithVoxel
+from .trellis2.modules.attention import config as attn_config
+from .trellis2.modules.sparse import config as sparse_config
 
 script_directory = os.path.dirname(os.path.abspath(__file__))
 comfy_path = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
@@ -320,7 +322,7 @@ class Trellis2LoadModel:
         return {
             "required": {
                 "modelname": (["TRELLIS.2-4B"],),
-                "backend": (["flash_attn","xformers"],{"default":"xformers"}),
+                "backend": (["flash_attn","xformers","sdpa"],{"default":"sdpa"}),
                 "device": (["cpu","cuda"],{"default":"cuda"}),
                 "low_vram": ("BOOLEAN",{"default":True}),
                 "keep_models_loaded": ("BOOLEAN", {"default":True}),
@@ -339,6 +341,10 @@ class Trellis2LoadModel:
         #os.environ["FLEX_GEMM_AUTOTUNE_CACHE_PATH"] = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'autotune_cache.json')
         #os.environ["FLEX_GEMM_AUTOTUNER_VERBOSE"] = '1'        
         os.environ['ATTN_BACKEND'] = backend
+        
+        # Force update the configuration modules
+        attn_config.set_backend(backend)
+        sparse_config.set_attn_backend(backend)
         
         reset_cuda()
         


### PR DESCRIPTION
This pull request makes improvements to the backend configuration for attention and sparse modules in the `nodes.py` file, allowing for more flexible and consistent backend selection. The most important changes are grouped below:

Backend configuration enhancements:

* Added `sdpa` as a selectable backend option for the `backend` parameter in the `INPUT_TYPES` function, expanding backend support beyond `flash_attn` and `xformers`.
* Updated the attention and sparse module configurations to forcefully set the backend using `attn_config.set_backend(backend)` and `sparse_config.set_attn_backend(backend)` in the `process` method, ensuring backend selection is consistently applied.

Imports for configuration modules:

* Imported `config` from `trellis2.modules.attention` and `trellis2.modules.sparse` as `attn_config` and `sparse_config`, respectively, to enable backend configuration updates.