### PR TITLE
Add torch.cuda.synchronize() before empty_cache() to fix Blackwell crash

### DIFF
--- a/trellis2/models/sc_vaes/sparse_unet_vae.py
+++ b/trellis2/models/sc_vaes/sparse_unet_vae.py
@@ -681,7 +681,9 @@ class SparseUnetVaeDecoder(nn.Module):
                     h = block(h)
                 # More frequent cache clearing in low_vram mode to reclaim memory between blocks
                 if self.low_vram:
+                    torch.cuda.synchronize()
                     torch.cuda.empty_cache()
+            torch.cuda.synchronize()
             torch.cuda.empty_cache()                        
         if self.low_vram:
             def fused_finalize(t):

--- a/trellis2/pipelines/trellis2_image_to_3d.py
+++ b/trellis2/pipelines/trellis2_image_to_3d.py
@@ -1166,11 +1166,13 @@ class Trellis2ImageTo3DPipeline(Pipeline):
             if not self.keep_models_loaded:
                 self.unload_tex_slat_flow_model_1024()               
             
+        torch.cuda.synchronize()
         torch.cuda.empty_cache()
         if generate_texture_slat:
             out_mesh = self.decode_latent(shape_slat, tex_slat, res, use_tiled=use_tiled)
         else:
             out_mesh = self.decode_latent(shape_slat, None, res, use_tiled=use_tiled)
+        torch.cuda.synchronize()
         torch.cuda.empty_cache()
         pbar.update(1)              
         if return_latent:
@@ -1518,11 +1520,13 @@ class Trellis2ImageTo3DPipeline(Pipeline):
             if not self.keep_models_loaded:
                 self.unload_tex_slat_flow_model_1024()         
             
+        torch.cuda.synchronize()
         torch.cuda.empty_cache()
         if generate_texture_slat:
             out_mesh = self.decode_latent(shape_slat, tex_slat, res, use_tiled=use_tiled)
         else:
             out_mesh = self.decode_latent(shape_slat, None, res, use_tiled=use_tiled)
+        torch.cuda.synchronize()
         torch.cuda.empty_cache()
         pbar.update(1)              
 
@@ -1728,11 +1732,13 @@ class Trellis2ImageTo3DPipeline(Pipeline):
             if pbar is not None:
                 pbar.update(1)
                  
+        torch.cuda.synchronize()
         torch.cuda.empty_cache()
         if generate_texture_slat:
             out_mesh = self.decode_latent(shape_slat, tex_slat, res, use_tiled=use_tiled)
         else:
             out_mesh = self.decode_latent(shape_slat, None, res, use_tiled=use_tiled)            
+        torch.cuda.synchronize()
         torch.cuda.empty_cache()
         
         if pbar is not None:
@@ -2479,8 +2485,10 @@ class Trellis2ImageTo3DPipeline(Pipeline):
             if not self.keep_models_loaded:
                 self.unload_shape_slat_flow_model_1024()
 
+        torch.cuda.synchronize()
         torch.cuda.empty_cache()
         pbr_voxel = self.decode_tex_slat(tex_slat)
+        torch.cuda.synchronize()
         torch.cuda.empty_cache()
         
         out_mesh, baseColorTexture, metallicRoughnessTexture = self.postprocess_mesh(mesh, pbr_voxel, resolution, texture_size, texture_alpha_mode, double_side_material, bake_on_vertices, use_custom_normals, mesh_cluster_threshold_cone_half_angle_rad)
@@ -2574,8 +2582,10 @@ class Trellis2ImageTo3DPipeline(Pipeline):
             if not self.keep_models_loaded:
                 self.unload_shape_slat_flow_model_1024()
                 
+        torch.cuda.synchronize()
         torch.cuda.empty_cache()
         pbr_voxel = self.decode_tex_slat(tex_slat)
+        torch.cuda.synchronize()
         torch.cuda.empty_cache()
         
         out_mesh, baseColorTexture, metallicRoughnessTexture = self.postprocess_mesh(mesh, pbr_voxel, resolution, texture_size, texture_alpha_mode, double_side_material, bake_on_vertices, use_custom_normals, mesh_cluster_threshold_cone_half_angle_rad)
@@ -2812,11 +2822,13 @@ class Trellis2ImageTo3DPipeline(Pipeline):
             if not self.keep_models_loaded:
                 self.unload_tex_slat_flow_model_1024()                 
                 
+        torch.cuda.synchronize()
         torch.cuda.empty_cache()
         if generate_texture_slat:
             out_mesh = self.decode_latent(shape_slat, tex_slat, res, use_tiled=use_tiled)
         else:
             out_mesh = self.decode_latent(shape_slat, None, res, use_tiled=use_tiled)
+        torch.cuda.synchronize()
         torch.cuda.empty_cache()
         
         if return_latent:


### PR DESCRIPTION
## Summary

`torch.cuda.empty_cache()` can free GPU memory that still has pending async work, causing `CUDA error: illegal memory access` on Blackwell GPUs (RTX 5090, sm_120). Adding `torch.cuda.synchronize()` before each `empty_cache()` call ensures all GPU work completes before memory is released.

**Related:** CuMesh also needs stream-awareness fixes — see https://github.com/visualbruno/CuMesh/issues/2. Both fixes are required; neither alone is sufficient.

### Why this is needed

`torch.cuda.empty_cache()` releases unused cached memory from PyTorch's allocator back to the GPU. However, it does not synchronize pending GPU operations first. On Blackwell GPUs, where PyTorch uses `cudaStreamNonBlocking` streams, this can race with in-flight kernels that are still using that memory.

### Changes

- `trellis2/pipelines/trellis2_image_to_3d.py` — add `torch.cuda.synchronize()` before all `torch.cuda.empty_cache()` calls in the pipeline
- `trellis2/models/sc_vaes/sparse_unet_vae.py` — add `torch.cuda.synchronize()` before `torch.cuda.empty_cache()` in the VAE decoder

### Testing

- Tested on RTX 5090 (sm_120), PyTorch 2.10.0+cu130, CUDA 13.0, Windows
- Full Trellis2 image-to-3D pipeline including mesh generation, refinement, and texturing
- Verified this fix is independently necessary: reverting it (with CuMesh fix in place) reproduces the crash