### PR TITLE
fix: initialize naf_download_if_missing attribute on DinoV3ProjFeatureExtractor

### DIFF
--- a/trellis2/trainers/flow_matching/mixins/image_conditioned_proj.py
+++ b/trellis2/trainers/flow_matching/mixins/image_conditioned_proj.py
@@ -404,6 +404,7 @@ class DinoV3ProjFeatureExtractor(nn.Module):
         
         # NAF upsampler (frozen, no trainable params)
         self.naf_model = None  # Lazy-loaded on first use to avoid import if not needed
+        self.naf_download_if_missing = True  # Allow downloading NAF model if not cached
 
         # Per-axis spatial tile factor for the NAF + proj_grid streaming path. 1 = un-tiled
         # (current behavior, default). >1 enables a streaming wrapper that tiles NAF and


### PR DESCRIPTION
> **AI assistance disclosure:** This patch was developed with the help of Claude (Anthropic) as a debugging and coding assistant. The bug was identified, reproduced, fix proposed, applied, and verified on my local setup. I have reviewed the one-line change and take responsibility for it. The change is trivial (single attribute initialization) and I am happy to revise based on review feedback.

## Summary

`DinoV3ProjFeatureExtractor._load_naf()` reads `self.naf_download_if_missing` to decide whether to download the NAF upsampler from `valeoai/NAF` via `torch.hub` when no local cache is present. The attribute is read but never initialized in `__init__`, so the first call raises `AttributeError` on any fresh setup where the user has not manually pre-downloaded the NAF repo.

Reproducer (Pixal3D checkpoints, no NAF in `torch.hub.get_dir()`):

```
File ".../trellis2/trainers/flow_matching/mixins/image_conditioned_proj.py", line 444, in _load_naf
    elif self.naf_download_if_missing:
AttributeError: 'DinoV3ProjFeatureExtractor' object has no attribute 'naf_download_if_missing'
```

## Fix

Initialize `self.naf_download_if_missing = True` in `__init__` so the lazy-load path can fall through to the HuggingFace download branch when nothing is cached. This matches the existing comment in `_load_naf` and the conditional structure of the method.

## Notes

- Default `True` preserves the documented behavior (lazy download on first use).
- Users who want to disable auto-download can still set `instance.naf_download_if_missing = False` after construction.
- No behavior change for users who already have NAF cached under `torch.hub.get_dir()`.