### PR TITLE
Center mesh and ensure mesh fits into camera

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -7048,6 +7048,9 @@ class Trellis2RenderMultiViewNvdiffrast:
     
     def render_view_nvdiffrast(self, mesh, elev, azim, resolution, scale, add_shading):
         verts = torch.from_numpy(mesh.vertices).float().cuda()
+        # Center mesh at origin
+        center = (verts.max(dim=0).values + verts.min(dim=0).values) * 0.5
+        verts = verts - center
         faces = torch.from_numpy(mesh.faces).int().cuda()
         uvs   = torch.from_numpy(mesh.visual.uv).float().cuda()
         
@@ -7058,7 +7061,11 @@ class Trellis2RenderMultiViewNvdiffrast:
         verts_cam = verts @ R.T + T
         
         verts_h = torch.cat([verts_cam, torch.ones_like(verts_cam[:, :1])], dim=1)
-        
+
+        # Check mesh size, ensure it fits inside the camera view
+        bbox = verts.max(dim=0).values - verts.min(dim=0).values
+        max_dim = bbox.max().item()
+        scale = max(scale, max_dim * 1.1)
         P = self.ortho_projection(scale, verts.device)
         verts_clip = (P @ verts_h.T).T
 


### PR DESCRIPTION
Ehy, nice to see the node in the official extension, glad to be able to help.

Anyway, this commit centers the mesh at the origin (same code from my previous comment/commit [here](https://github.com/visualbruno/ComfyUI-Trellis2/pull/145#issuecomment-4607575674)), and ensures the mesh fits into the camera.

Reason:
At the moment my big mesh gets cropped out of the camera. Increasing the ortho_scale doesn't help.

<img width="757" height="318" alt="image" src="https://github.com/user-attachments/assets/62609424-6295-485d-a38c-828ec481f132" />

Ensuring it fits into the camera view still isn't perfect ([commit](https://github.com/visualbruno/ComfyUI-Trellis2/pull/188/changes/353fa73eea5f1039cee1f2aa8f9ff0b764e7d1c1#diff-e485eb8bfa77e53e217e9b400c67298309ef679c6ecd69a1174366f48bb93499R7065)).

<img width="765" height="324" alt="image" src="https://github.com/user-attachments/assets/a7f68f23-ccd9-45fd-8f06-5ad585907ee3" />

Adding the center mesh fixes it ([code](https://github.com/visualbruno/ComfyUI-Trellis2/pull/188/changes/353fa73eea5f1039cee1f2aa8f9ff0b764e7d1c1#diff-e485eb8bfa77e53e217e9b400c67298309ef679c6ecd69a1174366f48bb93499R7051)).

<img width="753" height="321" alt="image" src="https://github.com/user-attachments/assets/ed6a4318-ca23-4082-a627-5d00c2e6d4cf" />
